### PR TITLE
Add typings definition file for use with TypeScript and enhanced intellisense

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,24 @@
+declare module "express-jwt-authz" {
+  import { Response, Request, NextFunction } from "express";
+  import { RequestHandler } from "express-serve-static-core";
+  /**
+   * @summary Validates a JWTs scope to authorize access to an endpoint
+   * @description Use together with express-jwt to both validate a JWT
+   * and make sure it has the correct permissions to call an endpoint.
+   * ```js
+   * const jwt = require('express-jwt');
+   * const jwtAuthz = require('express-jwt-authz');
+   *
+   * app.get('/users',
+   *  jwt({ secret: 'shared_secret' }),
+   *  jwtAuthz([ 'read:users' ]),
+   *  function(req, res) { ... });
+   * ```
+   * @param {string[]} expectedScopes list of the scope claims
+   */
+  function expressJwtAuthz(
+    expectedScopes: string[]
+  ): (req: Request, res: Response, next: NextFunction) => RequestHandler;
+
+  export = expressJwtAuthz;
+}


### PR DESCRIPTION
This commit adds definition file describing module definition together with
documentation based on module README content.
Adding this file enhances user experience in projects that are based on TypeScript and also
when the IDE used in development can read type definition for plain JavaScript modules in vanilla
JavaScript projects.


Here is a screenshot from VSCode from the TypeScript project and use in file with `.ts` extension:

![image](https://user-images.githubusercontent.com/14539/32996059-f3db0038-cd7d-11e7-862d-f3e7f7aee5f0.png)

and this one is form a plain javascript file when the type definition file is included in the module:

![image](https://user-images.githubusercontent.com/14539/32996072-2feb06fe-cd7e-11e7-9be2-be0c11d23621.png)



Thanks!