### PR TITLE
deprecated res.send(status, body)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 function error(res){
-  return res.send(401, 'Insufficient scope');
+  return res.status(401).send('Insufficient scope');
 }
 
 module.exports = function(expectedScopes) {


### PR DESCRIPTION
Express has deprecated the use of `.send(status, body)`.