### PR TITLE
fix express deprecated res.send(status, body)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 function error(res){
-  return res.send(401, 'Insufficient scope');
+  return res.status(401).json({ message: 'Insufficient scope' });
 }
 
 module.exports = function(expectedScopes) {

--- a/test/index.tests.js
+++ b/test/index.tests.js
@@ -13,13 +13,16 @@ describe('should 401 and "Insufficient scope"', function(){
     var params = {};
 
     return {
-      send: function(code, message){
+      status: function(code){
         params.code = code;
-        params.message = message;
+        return this;
+      },
+      json: function(json){
+        params.json = json;
       },
       assert: function(){
         expect(params.code).to.equal(401);
-        expect(params.message).to.equal('Insufficient scope');
+        expect(params.json.message).to.equal('Insufficient scope');
       }
     };
   }


### PR DESCRIPTION
Use res.status(status).send(body) instead node_modules/express-jwt-authz/lib/index.js:2:14