### PR TITLE
Change author link to absolute url

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you have found a bug or if you have a feature request, please report them at 
 
 ## Author
 
-[Auth0](auth0.com)
+[Auth0](https://auth0.com)
 
 ## License
 


### PR DESCRIPTION
Link was taking people to a page that didn't exist, so have made the url absolute.