### PR TITLE
If authentication fails, return a 'WWW-Authenticate' header, as per R…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ module.exports = (expectedScopes, options) => {
   return (req, res, next) => {
     const error = res => {
       const err_message = 'Insufficient scope';
+
       if (options && options.failWithError) {
         return next({
           statusCode: 403,
@@ -15,6 +16,11 @@ module.exports = (expectedScopes, options) => {
           message: err_message
         });
       }
+
+      res.append(
+        'WWW-Authenticate',
+        `Bearer scope="${expectedScopes.join(' ')}", error="${err_message}"`
+      );
       res.status(403).send(err_message);
     };
 

--- a/test/index.tests.js
+++ b/test/index.tests.js
@@ -11,8 +11,10 @@ describe('should error', () => {
 });
 
 describe('should 403 and "Insufficient scope"', () => {
-  function createResponse() {
+  function createResponse(expectedScopes = []) {
     const params = {};
+    let header;
+    let content;
 
     return {
       status(code) {
@@ -23,9 +25,17 @@ describe('should 403 and "Insufficient scope"', () => {
           }
         };
       },
+      append(_header, _content) {
+        header = _header;
+        content = _content;
+      },
       assert() {
         expect(params.code).to.equal(403);
         expect(params.message).to.equal('Insufficient scope');
+        expect(header).to.equal('WWW-Authenticate');
+        expect(content.split('scope="')[1].split('"')[0]).to.equal(
+          expectedScopes.join(' ')
+        );
       }
     };
   }
@@ -40,7 +50,7 @@ describe('should 403 and "Insufficient scope"', () => {
 
     const params = {};
 
-    const res = createResponse();
+    const res = createResponse(expectedScopes);
 
     jwtAuthz(expectedScopes)(req, res);
 
@@ -68,7 +78,7 @@ describe('should 403 and "Insufficient scope"', () => {
       user: {}
     };
 
-    const res = createResponse();
+    const res = createResponse(expectedScopes);
     jwtAuthz(expectedScopes)(req, res);
 
     res.assert();
@@ -78,7 +88,7 @@ describe('should 403 and "Insufficient scope"', () => {
     const expectedScopes = ['read:user'];
     const req = {};
 
-    const res = createResponse();
+    const res = createResponse(expectedScopes);
     jwtAuthz(expectedScopes)(req, res);
 
     res.assert();
@@ -90,7 +100,7 @@ describe('should 403 and "Insufficient scope"', () => {
       user: {}
     };
 
-    const res = createResponse();
+    const res = createResponse(expectedScopes);
     jwtAuthz(expectedScopes)(req, res);
 
     res.assert();


### PR DESCRIPTION
…FC 6750, indicating the expected scopes.

The PR Resolves #19 .

Open is the content of the header. Currently I omit the 'realm' param, as the RFC describes it as optional. If we look at another library (https://github.com/LionC/express-basic-auth/blob/master/index.js), they actually make realm configurable. But I think one advantage of this extension is the ease of use, so it might not be optimal to add another config param just for this.

Other question is, if the header should be set, even if we fail with error (before returning with next), effectively moving line 20-23 before line 12.