### PR TITLE
Added support for array scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,53 @@ app.get('/users',
   function(req, res) { ... });
 ```
 
-The JWT must have a `scope` claim and it must be a string that specifies permissions separated by spaces. For example:
+If multiple scopes are provided, the user must have _any_ the required scopes.
+
+```javascript
+app.post('/users',
+  jwt({ secret: 'shared_secret' }),
+  jwtAuthz([ 'read:users', 'write:users' ], {}),
+  function(req, res) { ... });
+
+// This user will be denied access
+var authorizedUser = {
+  scope: 'read:users'
+};
+```
+
+To check that the user has _all_ the scopes provided, use the `checkAllScopes: true` option:
+
+```javascript
+app.post('/users',
+  jwt({ secret: 'shared_secret' }),
+  jwtAuthz([ 'read:users', 'write:users' ], { checkAllScopes: true }),
+  function(req, res) { ... });
+
+// This user will have access
+var authorizedUser = {
+  scope: 'read:users write:users'
+};
+
+// This user will NOT have access
+var unauthorizedUser = {
+  scope: 'read:users'
+};
+```
+
+The JWT must have a `scope` claim and it must either be a string of space-separated permissions or an array of strings. For example:
 
 ```
+// String:
 "write:users read:users"
+
+// Array:
+["write:users", "read:users"]
 ```
 
 ## Options
 
 - `failWithError`: When set to `true`, will forward errors to `next` instead of ending the response directly. Defaults to `false`.
+- `checkAllScopes`: When set to `true`, all the expected scopes will be checked against the user's scopes. Defaults to `false`.
 
 ## Issue Reporting
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,11 +27,27 @@ module.exports = (expectedScopes, options) => {
     if (expectedScopes.length === 0) {
       return next();
     }
-    if (!req.user || typeof req.user.scope !== 'string') {
+
+    let userScopes = [];
+
+    if (!req.user) {
       return error(res);
     }
-    const scopes = req.user.scope.split(' ');
-    const allowed = expectedScopes.some(scope => scopes.includes(scope));
+
+    if (typeof req.user.scope === 'string') {
+      userScopes = req.user.scope.split(' ');
+    } else if (Array.isArray(req.user.scope)) {
+      userScopes = req.user.scope;
+    } else {
+      return error(res);
+    }
+
+    let allowed;
+    if (options && options.checkAllScopes) {
+      allowed = expectedScopes.every(scope => userScopes.includes(scope));
+    } else {
+      allowed = expectedScopes.some(scope => userScopes.includes(scope));
+    }
 
     return allowed ? next() : error(res);
   };


### PR DESCRIPTION
This PR adds support for array scopes (similar to #15 but with tests):
```javascript
var user = {
  scope: ['read:user', 'write:user']
};
```

I've also added an option to validate that _all_ the required scopes are included:

```javascript
const req = {
  user: {
    // This user is missing 'delete:user'
    scope: 'read:user write:user'
  }
};

// This will fail because the users doesn't have the 'delete:user' scope
jwtAuthz(['read:user', 'write:user', 'delete:user'], { checkAllScopes: true })(req, res);
```

This fixes #14 and resolves #1.