### PR TITLE
Added support for custom keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The JWT must have a `scope` claim and it must either be a string of space-separa
 
 - `failWithError`: When set to `true`, will forward errors to `next` instead of ending the response directly. Defaults to `false`.
 - `checkAllScopes`: When set to `true`, all the expected scopes will be checked against the user's scopes. Defaults to `false`.
-- `customKey`: By default, permissions are checked agaisnt `user.scope`. This can be customized with this option. Defaults to `"scope"`.
+- `customScopeKey`: By default, permissions are checked agaisnt `user.scope`. This can be customized with this option. Defaults to `"scope"`.
 
 ## Issue Reporting
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The JWT must have a `scope` claim and it must either be a string of space-separa
 
 - `failWithError`: When set to `true`, will forward errors to `next` instead of ending the response directly. Defaults to `false`.
 - `checkAllScopes`: When set to `true`, all the expected scopes will be checked against the user's scopes. Defaults to `false`.
-- `customScopeKey`: By default, permissions are checked against `user.scope`. This can be customized with this option. Defaults to `"scope"`.
+- `customScopeKey`: The property name to check for the scope. By default, permissions are checked against `user.scope`, but you can change it to be `user.myCustomScopeKey` with this option. Defaults to `scope`.
 
 ## Issue Reporting
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The JWT must have a `scope` claim and it must either be a string of space-separa
 
 - `failWithError`: When set to `true`, will forward errors to `next` instead of ending the response directly. Defaults to `false`.
 - `checkAllScopes`: When set to `true`, all the expected scopes will be checked against the user's scopes. Defaults to `false`.
+- `customKey`: By default, permissions are checked agaisnt `user.scope`. This can be customized with this option. Defaults to `"scope"`.
 
 ## Issue Reporting
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The JWT must have a `scope` claim and it must either be a string of space-separa
 
 - `failWithError`: When set to `true`, will forward errors to `next` instead of ending the response directly. Defaults to `false`.
 - `checkAllScopes`: When set to `true`, all the expected scopes will be checked against the user's scopes. Defaults to `false`.
-- `customScopeKey`: By default, permissions are checked agaisnt `user.scope`. This can be customized with this option. Defaults to `"scope"`.
+- `customScopeKey`: By default, permissions are checked against `user.scope`. This can be customized with this option. Defaults to `"scope"`.
 
 ## Issue Reporting
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,10 +32,10 @@ module.exports = (expectedScopes, options) => {
     let scopeKey = 'scope';
     if (
       options &&
-      options.customKey != null &&
-      typeof options.customKey === 'string'
+      options.customScopeKey != null &&
+      typeof options.customScopeKey === 'string'
     ) {
-      scopeKey = options.customKey;
+      scopeKey = options.customScopeKey;
     }
 
     if (!req.user) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,15 +29,23 @@ module.exports = (expectedScopes, options) => {
     }
 
     let userScopes = [];
+    let scopeKey = 'scope';
+    if (
+      options &&
+      options.customKey != null &&
+      typeof options.customKey === 'string'
+    ) {
+      scopeKey = options.customKey;
+    }
 
     if (!req.user) {
       return error(res);
     }
 
-    if (typeof req.user.scope === 'string') {
-      userScopes = req.user.scope.split(' ');
+    if (typeof req.user[scopeKey] === 'string') {
+      userScopes = req.user[scopeKey].split(' ');
     } else if (Array.isArray(req.user.scope)) {
-      userScopes = req.user.scope;
+      userScopes = req.user[scopeKey];
     } else {
       return error(res);
     }

--- a/test/index.tests.js
+++ b/test/index.tests.js
@@ -82,14 +82,14 @@ describe('should 403 and "Insufficient scope"', () => {
     res.assert();
   });
 
-  it('when using a customKey and invalid scopes', () => {
+  it('when using a customScopeKey and invalid scopes', () => {
     const expectedScopes = ['read:user'];
     const req = {
       user: {}
     };
 
     const res = createResponse(expectedScopes);
-    jwtAuthz(expectedScopes, { customKey: 'permissions' })(req, res);
+    jwtAuthz(expectedScopes, { customScopeKey: 'permissions' })(req, res);
 
     res.assert();
   });
@@ -195,14 +195,14 @@ describe('should call next', () => {
     );
   });
 
-  it('when using a customKey', done => {
+  it('when using a customScopeKey', done => {
     const req = {
       user: {
         permissions: 'write:user'
       }
     };
 
-    jwtAuthz(['read:user', 'write:user'], { customKey: 'permissions' })(
+    jwtAuthz(['read:user', 'write:user'], { customScopeKey: 'permissions' })(
       req,
       null,
       done

--- a/test/index.tests.js
+++ b/test/index.tests.js
@@ -82,6 +82,18 @@ describe('should 403 and "Insufficient scope"', () => {
     res.assert();
   });
 
+  it('when using a customKey and invalid scopes', () => {
+    const expectedScopes = ['read:user'];
+    const req = {
+      user: {}
+    };
+
+    const res = createResponse(expectedScopes);
+    jwtAuthz(expectedScopes, { customKey: 'permissions' })(req, res);
+
+    res.assert();
+  });
+
   it('when user.scope is missing some of the expectedScopes and options.checkAllScopes is true', () => {
     const expectedScopes = ['read:user', 'write:user', 'delete:user'];
     const req = {
@@ -177,6 +189,20 @@ describe('should call next', () => {
     };
 
     jwtAuthz(['read:user', 'write:user'], { checkAllScopes: true })(
+      req,
+      null,
+      done
+    );
+  });
+
+  it('when using a customKey', done => {
+    const req = {
+      user: {
+        permissions: 'write:user'
+      }
+    };
+
+    jwtAuthz(['read:user', 'write:user'], { customKey: 'permissions' })(
       req,
       null,
       done


### PR DESCRIPTION
This adds support for a `customKey` option that can be useful when using API scopes with Auth0. For instance, it's possible that the scopes are on the `user.permissions` key, like so:

```javascript
// This user will have access
var authorizedUser = {
  permissions: 'read:users write:users'
};

app.post('/users',
  jwt({ secret: 'shared_secret' }),
  jwtAuthz([ 'read:users', 'write:users' ], { customKey: 'permissions' }),
  function(req, res) { ... });
```

This fixes #2. It does **not** support nested keys, though, because I didn't want to introduce a dependency like `lodash.set`. I can add that if necessary.