### PR TITLE
Allow custom scope key to be an array

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,7 @@ module.exports = (expectedScopes, options) => {
 
     if (typeof req.user[scopeKey] === 'string') {
       userScopes = req.user[scopeKey].split(' ');
-    } else if (Array.isArray(req.user.scope)) {
+    } else if (Array.isArray(req.user[scopeKey])) {
       userScopes = req.user[scopeKey];
     } else {
       return error(res);

--- a/test/index.tests.js
+++ b/test/index.tests.js
@@ -208,4 +208,18 @@ describe('should call next', () => {
       done
     );
   });
+
+  it('when using a customScopeKey that is an array', done => {
+    const req = {
+      user: {
+        permissions: ['write:user']
+      }
+    };
+
+    jwtAuthz(['read:user', 'write:user'], { customScopeKey: 'permissions' })(
+      req,
+      null,
+      done
+    );
+  });
 });


### PR DESCRIPTION
Currently, the custom scope key functionality only works if the key results in a space-separated string.

This PR fixes the functionality to match the documentation, where the key can be a space separated string _or_ an array.