### PR TITLE
Use AuthenticationError

### DIFF
--- a/lib/errors/AuthenticationError.js
+++ b/lib/errors/AuthenticationError.js
@@ -1,0 +1,10 @@
+module.exports = function AuthenticationError(message, statusCode, error) {
+  Error.captureStackTrace(this, this.constructor);
+  this.name = this.constructor.name;
+  this.message = message;
+
+  this.statusCode = statusCode || 403;
+  this.error = error || 'Forbidden';
+};
+
+require('util').inherits(module.exports, Error);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,5 @@
+const AuthenticationError = require('./errors/AuthenticationError');
+
 module.exports = (expectedScopes, options) => {
   if (!Array.isArray(expectedScopes)) {
     throw new Error(
@@ -10,11 +12,7 @@ module.exports = (expectedScopes, options) => {
       const err_message = 'Insufficient scope';
 
       if (options && options.failWithError) {
-        return next({
-          statusCode: 403,
-          error: 'Forbidden',
-          message: err_message
-        });
+        return next(new AuthenticationError(err_message));
       }
 
       res.append(


### PR DESCRIPTION
How's this for error handling? I feel like giving an actual error object when the user wants to `failWithError` is better than a plain object. All the previous properties are still accessible.