### PR TITLE
Add option for custom user key (customUserKey)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# 2.4.0
+
+- Added support for a custom user key (`customUserKey`)
+
 # 2.3.0
 
 - Added support for a custom scope key (`customScopeKey`)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ The JWT must have a `scope` claim and it must either be a string of space-separa
 
 - `failWithError`: When set to `true`, will forward errors to `next` instead of ending the response directly. Defaults to `false`.
 - `checkAllScopes`: When set to `true`, all the expected scopes will be checked against the user's scopes. Defaults to `false`.
-- `customScopeKey`: The property name to check for the scope. By default, permissions are checked against `user.scope`, but you can change it to be `user.myCustomScopeKey` with this option. Defaults to `scope`.
+- `customUserKey`: The property name to check for the scope key. By default, permissions are checked against `req.user`, but you can change it to be `req.myCustomUserKey` with this option. Defaults to `user`.
+- `customScopeKey`: The property name to check for the actual scope. By default, permissions are checked against `user.scope`, but you can change it to be `user.myCustomScopeKey` with this option. Defaults to `scope`.
+
 
 ## Issue Reporting
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -13,6 +13,7 @@ declare namespace jwtAuthz {
   export interface AuthzOptions {
     failWithError?: boolean;
     customScopeKey?: string;
+    customUserKey?: string;
     checkAllScopes?: boolean;
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,6 @@ module.exports = (expectedScopes, options) => {
       );
       res.status(403).send(err_message);
     };
-
     if (expectedScopes.length === 0) {
       return next();
     }
@@ -37,15 +36,23 @@ module.exports = (expectedScopes, options) => {
     ) {
       scopeKey = options.customScopeKey;
     }
-
-    if (!req.user) {
-      return error(res);
+    let userKey = 'user';
+    if (
+      options &&
+      options.customUserKey != null &&
+      typeof options.customUserKey === 'string'
+    ) {
+      userKey = options.customUserKey;
     }
 
-    if (typeof req.user[scopeKey] === 'string') {
-      userScopes = req.user[scopeKey].split(' ');
-    } else if (Array.isArray(req.user[scopeKey])) {
-      userScopes = req.user[scopeKey];
+
+    if (!req[userKey]) {
+      return error(res);
+    }
+    if (typeof req[userKey][scopeKey] === 'string') {
+      userScopes = req[userKey][scopeKey].split(' ');
+    } else if (Array.isArray(req[userKey][scopeKey])) {
+      userScopes = req[userKey][scopeKey];
     } else {
       return error(res);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-jwt-authz",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Validate a JWTs scope to authorize access to an endpoint",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
express-jwt has the option to customize the key holding the jwt decoded info in the req object. This change, or whatever version you decide to merge, allows for the scope to be located in the custom key.

```javascript
var jwt = require('express-jwt');
var jwtAuthz = require('express-jwt-authz');

var options = {
  //find the scope in req.access['scp']
  customUserKey: 'access', 
  customScopeKey: 'scp',
};

app.get('/users',
  jwt({ secret: 'shared_secret' }),
  jwtAuthz([ 'read:users' ], options),
  function(req, res) { ... });
```