### PR TITLE
Add 'jsonErrorResponse' option and make the server response dependent on it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The JWT must have a `scope` claim and it must either be a string of space-separa
 - `checkAllScopes`: When set to `true`, all the expected scopes will be checked against the user's scopes. Defaults to `false`.
 - `customUserKey`: The property name to check for the scope key. By default, permissions are checked against `req.user`, but you can change it to be `req.myCustomUserKey` with this option. Defaults to `user`.
 - `customScopeKey`: The property name to check for the actual scope. By default, permissions are checked against `user.scope`, but you can change it to be `user.myCustomScopeKey` with this option. Defaults to `scope`.
+- `jsonErrorResponse`: When set to `true`, will response error as `json`. Defaults to `false`. Defaults response to `html`.
 
 
 ## Issue Reporting

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,17 @@ module.exports = (expectedScopes, options) => {
         'WWW-Authenticate',
         `Bearer scope="${expectedScopes.join(' ')}", error="${err_message}"`
       );
-      res.status(403).send(err_message);
+
+      if (
+        options &&
+        options.jsonErrorResponse != null &&
+        options.jsonErrorResponse === true
+      ) {
+        res.status(403).json({ message: err_message });
+      }
+      else {
+        res.status(403).send(err_message);
+      }
     };
     if (expectedScopes.length === 0) {
       return next();


### PR DESCRIPTION
### Description

The purpose of this PR is to add an option, which in case of "Insufficient scope" error, will determine the response type.
This is my first PR, please have that in mind.

### Testing

After modifying "lib/index.js" file, I have copied it's content to my NodeJS API (to the new file called "scope.js").
Then I have included it in my API's "index.js" and used it to check permissions.

I have tested these cases (in postman): 
- option 'jsonErrorResponse' is not provided
- option is provided, but contains non boolean value type
- option is provided and contains boolean false value
- option is provided and contains boolean true value

In the first 3 cases server response value was plain text "Insufficient scope".
The last case returned JSON: `{ message: "Insufficient scope" }`.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
