### PR TITLE
Restify support.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,11 +17,19 @@ module.exports = (expectedScopes, options) => {
         });
       }
 
-      res.append(
-        'WWW-Authenticate',
-        `Bearer scope="${expectedScopes.join(' ')}", error="${err_message}"`
-      );
-      res.status(403).send(err_message);
+      if (typeof res.header === 'function') { // restify support
+        res.header(
+          'WWW-Authenticate',
+          `Bearer scope="${expectedScopes.join(' ')}", error="${err_message}"`
+        );
+        res.send(403, err_message);
+      } else {
+        res.append(
+          'WWW-Authenticate',
+          `Bearer scope="${expectedScopes.join(' ')}", error="${err_message}"`
+        );
+        res.status(403).send(err_message);
+      }
     };
     if (expectedScopes.length === 0) {
       return next();


### PR DESCRIPTION
Pretty basic change to support Restify's response object.  Currently I'm using restify with express-jwt and express-jwt-authz but ran into a failure when scope is unexpected:

```
TypeError: res.append is not a function
```

Obviously this is because of the difference in Express and Restify's response object functions.  Otherwise I haven't run into issues and it would be great to continue using these libraries.

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x ] All active GitHub checks for tests, formatting, and security are passing
- [x ] The correct base branch is being used, if not `master`
