### PR TITLE
Add note about newer express-jwt changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ Validate a JWTs `scope` to authorize access to an endpoint.
 
 Use together with [express-jwt](https://github.com/auth0/express-jwt) to both validate a JWT and make sure it has the correct permissions to call an endpoint.
 
+:note: `express-jwt` sets the decoded JWT payload on `req.auth` since version `6.0.0`, so make sure to set `customUserKey: 'auth'` in the options provided to `express-jwt-authz` if you are using that version or newer.
+
 ```javascript
 var jwt = require('express-jwt');
 var jwtAuthz = require('express-jwt-authz');
 
-var options = {};
+var options = { customUserKey: 'auth' };
 app.get('/users',
   jwt({ secret: 'shared_secret' }),
   jwtAuthz([ 'read:users' ], options),
@@ -26,9 +28,10 @@ app.get('/users',
 If multiple scopes are provided, the user must have _at least one_ of the specified scopes.
 
 ```javascript
+var options = { customUserKey: 'auth' };
 app.post('/users',
   jwt({ secret: 'shared_secret' }),
-  jwtAuthz([ 'read:users', 'write:users' ], {}),
+  jwtAuthz([ 'read:users', 'write:users' ], options),
   function(req, res) { ... });
 
 // This user will be granted access
@@ -42,7 +45,7 @@ To check that the user has _all_ the scopes provided, use the `checkAllScopes: t
 ```javascript
 app.post('/users',
   jwt({ secret: 'shared_secret' }),
-  jwtAuthz([ 'read:users', 'write:users' ], { checkAllScopes: true }),
+  jwtAuthz([ 'read:users', 'write:users' ], { checkAllScopes: true, customUserKey: 'auth' }),
   function(req, res) { ... });
 
 // This user will have access
@@ -72,7 +75,6 @@ The JWT must have a `scope` claim and it must either be a string of space-separa
 - `checkAllScopes`: When set to `true`, all the expected scopes will be checked against the user's scopes. Defaults to `false`.
 - `customUserKey`: The property name to check for the scope key. By default, permissions are checked against `req.user`, but you can change it to be `req.myCustomUserKey` with this option. Defaults to `user`.
 - `customScopeKey`: The property name to check for the actual scope. By default, permissions are checked against `user.scope`, but you can change it to be `user.myCustomScopeKey` with this option. Defaults to `scope`.
-
 
 ## Issue Reporting
 


### PR DESCRIPTION
### Description

Newer versions of express-jwt set the JWT payload on `req.auth` instead of `req.user`. This PR adds a note to the readme that clarifies this and changes the provided sample to demonstrate this.


### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
